### PR TITLE
Change Box Component

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ContainerProps, Container } from './style';
 
 interface BoxProps extends ContainerProps {
-  children: JSX.Element;
+  children: JSX.Element | JSX.Element[];
 }
 
 const Box = ({ children, ...props }: BoxProps) => {

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { BoxProps, Container } from './style';
+import { ContainerProps, Container } from './style';
 
-const Box = (props: BoxProps) => {
-  return <Container {...props}></Container>;
+interface BoxProps extends ContainerProps {
+  children: JSX.Element;
+}
+
+const Box = ({ children, ...props }: BoxProps) => {
+  return <Container {...props}>{children}</Container>;
 };
 
 export default Box;

--- a/src/components/Box/style.ts
+++ b/src/components/Box/style.ts
@@ -2,19 +2,19 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import theme from '../../../styles/theme';
 
-export interface BoxProps {
+export interface ContainerProps {
   width: number;
   height: number;
 }
 
-const getSize = ({ width, height }: BoxProps) => {
+const getSize = ({ width, height }: ContainerProps) => {
   return css`
     width: ${width}px;
     height: ${height}px;
   `;
 };
 
-export const Container = styled.div<BoxProps>`
+export const Container = styled.div<ContainerProps>`
   ${getSize};
   border: 1px solid ${theme.style.lightgrey};
   border-radius: 8px;

--- a/src/components/Box/style.ts
+++ b/src/components/Box/style.ts
@@ -22,5 +22,5 @@ export const Container = styled.div<ContainerProps>`
   margin-top: 64px;
   padding: 80px 48px;
   background: ${theme.style.white};
-  display: flex;
+  display: block;
 `;


### PR DESCRIPTION
## 개요
Box component의 props와 interface이름을 수정했습니다.

## 작업내용

- Container의 크기, 색상 등 결정하는 interface를 BoxProps -> ContainerProps로 변경.

새로 생성한 interface BoxProps
```
interface BoxProps extends ContainerProps {
  children: JSX.Element | JSX.Element[];
}
```
Box에 컴포넌트들을 넣을 수 있도록 children props을 추가했습니다.

- 여러개 컴포넌트들이 block으로 display되도록 ContainerProps변경

`display: block;`

## 주의사항
