### PR TITLE
Change Input Component

### DIFF
--- a/src/components/Input/index.stories.tsx
+++ b/src/components/Input/index.stories.tsx
@@ -14,16 +14,10 @@ const Template: ComponentStory<typeof Input> = args => (
   </GlobalThemeProvider>
 );
 
-export const DefaultView = Template.bind({});
-DefaultView.args = {
-  backgroundColor: '#ffffff',
-  fontColor: '#6B6B6B',
-  borderColor: '#BFBFBF',
+export const DefaultInput = Template.bind({});
+DefaultInput.args = {
   width: 375,
   height: 40,
-  fontSize: 16,
-  borderRadius: 8,
   value: 'input Value',
   placeholder: 'input placeholder',
-  type: 'text',
 };

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -3,13 +3,14 @@ import { SInputProps, StyledInput } from './style';
 
 interface InputProps extends SInputProps {
   value?: string;
-  type?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent) => void;
 }
 
-const Input = ({ value, type = 'text', placeholder, onChange, ...props }: InputProps) => {
-  return <StyledInput type={type} value={value} placeholder={placeholder} onChange={onChange} {...props}></StyledInput>;
+const Input = ({ value, placeholder, onChange, ...props }: InputProps) => {
+  return (
+    <StyledInput type={'text'} value={value} placeholder={placeholder} onChange={onChange} {...props}></StyledInput>
+  );
 };
 
 export default Input;

--- a/src/components/Input/style.ts
+++ b/src/components/Input/style.ts
@@ -1,42 +1,51 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+import theme from '../../../styles/theme';
+
+const inputTheme = theme.style.input;
 
 export interface SInputProps {
-  backgroundColor: string;
-  fontColor: string;
-  borderColor?: string;
-  borderRadius: number;
-  fontSize: number;
+  backgroundColor?: keyof typeof inputTheme.backgroundColor;
+  fontColor?: keyof typeof inputTheme.fontColor;
+  borderColor?: keyof typeof inputTheme.borderColor;
+  fontSize?: 'sm' | 'md';
   width: number;
   height: number;
 }
 
-const getColors = ({ backgroundColor, fontColor, borderColor = 'none' }: SInputProps) => {
+const getColors = ({ backgroundColor = 'white', fontColor = 'gray', borderColor = 'lightgray' }: SInputProps) => {
   const getBorder = () => {
     if (borderColor !== 'none')
       return `
         border: 1px solid;
-        border-color: ${borderColor}
+        border-color: ${inputTheme.borderColor[borderColor]};
         `;
   };
   return css`
     ${getBorder()};
-    background-color: ${backgroundColor};
-    color: ${fontColor};
+    background-color: ${inputTheme.backgroundColor[backgroundColor]};
+    color: ${inputTheme.fontColor[fontColor]};
   `;
 };
 
-const getLayouts = ({ borderRadius, fontSize, width, height }: SInputProps) => {
+const getFont = ({ fontSize = 'md' }: SInputProps) => {
+  const sizes = inputTheme.sizes;
+  return css`
+    font-size: ${sizes[fontSize].fontSize};
+  `;
+};
+
+const getLayouts = ({ width, height }: SInputProps) => {
   return css`
     width: ${width}px;
     height: ${height}px;
-    font-size: ${fontSize}px;
-    border-radius: ${borderRadius}px;
+    border-radius: 8px;
     padding-left: 1rem;
   `;
 };
 
 export const StyledInput = styled.input<SInputProps>`
   ${getColors};
+  ${getFont};
   ${getLayouts};
 `;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -77,6 +77,30 @@ const style = {
       lg: { fontSize: '1.5rem', weight: 'medium' },
     },
   },
+  input: {
+    backgroundColor: {
+      white: '#FFFFFF',
+    },
+    fontColor: {
+      gray: '#878787',
+      black: '#000000',
+    },
+    borderColor: {
+      lightgray: '#BFBFBF',
+      none: null,
+    },
+    weight: {
+      bold: 700,
+      medium: 500,
+      regular: 400,
+      light: 300,
+      thin: 100,
+    },
+    sizes: {
+      sm: { fontSize: '0.875rem' },
+      md: { fontSize: '1rem' },
+    },
+  },
   primary: '#1896BD',
   yellow: '#FFB84D',
   white: '#FFFFFF',


### PR DESCRIPTION
## 개요
Input 컴포넌트에서 불필요하게 많은 props를 요구하는 문제를 해결하고자 진행되었습니다.

## 작업내용
### [변화내용]
#### 1.  theme.ts의 사용
`backgroundColor`, `fontColor`, `borderColor`에서 string으로 받던 색을 theme.ts에 등록하여 범위내에서 선택하여 사용할 수 있도록 변경하였습니다. 또한 fontSize도 sm과 md로 나눠 사이즈에 맞게 가져오도록 크기를 수정하였습니다.
##### SInputProps변경 (input props의 타입)
```typescript
export interface SInputProps {
  backgroundColor?: keyof typeof inputTheme.backgroundColor;
  fontColor?: keyof typeof inputTheme.fontColor;
  borderColor?: keyof typeof inputTheme.borderColor;
  fontSize?: 'sm' | 'md';
  width: number;
  height: number;
}
```
##### `backgroundColor`, `fontColor`, `borderColor`의 색을 선택하여 가져오도록 수정 
```typescript
const getColors = ({ backgroundColor = 'white', fontColor = 'gray', borderColor = 'lightgray' }: SInputProps) => {
  const getBorder = () => {
    if (borderColor !== 'none')
      return `
        border: 1px solid;
        border-color: ${inputTheme.borderColor[borderColor]};
        `;
  };
  return css`
    ${getBorder()};
    background-color: ${inputTheme.backgroundColor[backgroundColor]};
    color: ${inputTheme.fontColor[fontColor]};
  `;
};
```
##### `fontSize`를 사이즈를 선택하여 가져오도록 수정
```typescript
const getFont = ({ fontSize = 'md' }: SInputProps) => {
  const sizes = inputTheme.sizes;
  return css`
    font-size: ${sizes[fontSize].fontSize};
  `;
};
```
#### 2. 불필요한 props 제거
기존에 input Component내에서 스타일 변화가 없던  `border-radius`, `type`을 argument로부터 받지 않고 고정된 값을 사용하도록 수정하였습니다.
##### `border-radius`를 8px(피그마 디자인 공통)로 고정
```typescript
const getLayouts = ({ width, height }: SInputProps) => {
  return css`
    width: ${width}px;
    height: ${height}px;
    border-radius: 8px;
    padding-left: 1rem;
  `;
};
```
##### index.tsx에서 type은 text에서 바뀌지 않기에 text고정
```typescript
const Input = ({ value, placeholder, onChange, ...props }: InputProps) => {
  return (
    <StyledInput type={'text'} value={value} placeholder={placeholder} onChange={onChange} {...props}></StyledInput>
  );
};
```

### [결과]
#### Storybook 설정창
![image](https://user-images.githubusercontent.com/48820696/161475628-b642fac6-696c-4aec-9474-003ae21d3180.png)

#### Chromatic 주소
https://www.chromatic.com/component?appId=624819a68844fb003a06cdbc&csfId=components-input&buildNumber=8&k=624a7b4233c649003a5c09e9-1200-interactive-true&h=2&b=-1

## 주의사항
theme.ts에 input에 관한 스타일이 추가되었습니다.
##### theme.ts 변경내용
```typescript
  input: {
    backgroundColor: {
      white: '#FFFFFF',
    },
    fontColor: {
      gray: '#878787',
      black: '#000000',
    },
    borderColor: {
      lightgray: '#BFBFBF',
      none: null,
    },
    weight: {
      bold: 700,
      medium: 500,
      regular: 400,
      light: 300,
      thin: 100,
    },
    sizes: {
      sm: { fontSize: '0.875rem' },
      md: { fontSize: '1rem' },
    },
```
