### PR TITLE
Change Checkbox Component

### DIFF
--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -18,17 +18,6 @@ export const DefaultView = Template.bind({});
 DefaultView.args = {
   label: '광고성 정보 수신 동의(선택)',
   link: false,
-  box: {
-    width: 300,
-    height: 30,
-    padding: '1.5px',
-    backgroundColor: '#ffffff',
-  },
-  input: {
-    backgroundColor: '#373737',
-  },
-  text: {
-    fontSize: 12,
-    fontColor: '#373737',
-  },
+  width: '100px',
+  height: '30px',
 };

--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -18,6 +18,6 @@ export const DefaultView = Template.bind({});
 DefaultView.args = {
   label: '광고성 정보 수신 동의(선택)',
   link: false,
-  width: '100px',
+  width: '300px',
   height: '30px',
 };

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,7 +1,6 @@
 import {
   EmptyDiv,
   SCheckboxComponentBox,
-  SCheckboxComponentInput,
   SCheckboxComponentText,
   StyledCheckbox,
   StyledCheckboxDetail,
@@ -9,38 +8,20 @@ import {
   StyledCheckboxText,
 } from './style';
 
-interface CheckBoxProps {
+interface CheckBoxProps extends SCheckboxComponentBox, SCheckboxComponentText {
   label: string;
-  link?: boolean;
-  box: SCheckboxComponentBox;
-  input: SCheckboxComponentInput;
-  text: SCheckboxComponentText;
 }
 
-const CheckboxComponents = {
-  Box(box: SCheckboxComponentBox) {
-    return <StyledCheckbox {...box}></StyledCheckbox>;
-  },
-  Input(input: SCheckboxComponentInput) {
-    return <StyledCheckboxInput type="checkbox" {...input} />;
-  },
-  Text(text: SCheckboxComponentText) {
-    return <StyledCheckboxText {...text}></StyledCheckboxText>;
-  },
-  Detail(text: SCheckboxComponentText) {
-    return <StyledCheckboxDetail {...text}></StyledCheckboxDetail>;
-  },
-};
-
-const Checkbox = ({ label, link, box, input, text }: CheckBoxProps) => {
+const Checkbox = ({ label, link, width = '100%', height = '30px' }: CheckBoxProps) => {
+  const box = { width, height };
   return (
-    <CheckboxComponents.Box {...box}>
+    <StyledCheckbox {...box}>
       <EmptyDiv>
-        <CheckboxComponents.Input {...input} />
-        <CheckboxComponents.Text {...text}>{label}</CheckboxComponents.Text>
+        <StyledCheckboxInput type={'checkbox'} />
+        <StyledCheckboxText>{label}</StyledCheckboxText>
       </EmptyDiv>
-      {link && <CheckboxComponents.Detail {...text}>보기</CheckboxComponents.Detail>}
-    </CheckboxComponents.Box>
+      {link && <StyledCheckboxDetail>보기</StyledCheckboxDetail>}
+    </StyledCheckbox>
   );
 };
 

--- a/src/components/Checkbox/style.ts
+++ b/src/components/Checkbox/style.ts
@@ -16,7 +16,6 @@ const getCheckboxBox = ({ ...box }) => {
     width: ${box.width};
     height: ${box.height};
     padding: 0.4rem;
-    background-color: #FFFFFF;
   `;
 };
 const getCheckboxText = ({ ...text }) => {

--- a/src/components/Checkbox/style.ts
+++ b/src/components/Checkbox/style.ts
@@ -1,56 +1,45 @@
 import styled from '@emotion/styled';
 
 export interface SCheckboxComponentBox {
-  width: number;
-  height: number;
-  padding: string;
-  backgroundColor: string;
-}
-export interface SCheckboxComponentInput {
-  backgroundColor: string;
+  width?: string;
+  height?: string;
 }
 export interface SCheckboxComponentText {
-  fontSize: number;
-  fontColor: string;
+  link?: boolean;
 }
 
 const getCheckboxBox = ({ ...box }) => {
   return `
-    width: ${box.width}px;
-    height: ${box.height}px;
-    padding: ${box.padding};
-    background-color: ${box.backgroundColor};
+    display: flex;
+    flex-basis: auto;
+    align-items: center;
+    width: ${box.width};
+    height: ${box.height};
+    padding: 0.4rem;
+    background-color: #FFFFFF;
   `;
 };
-const getCheckboxInput = ({ ...input }) => {
-  return `
-    accent-color: ${input.backgroundColor};
-  `;
-};
-const getCheckboxText = ({ link = false, ...text }) => {
-  const isFloatRight = () => (link ? 'margin-left: auto;' : '');
+const getCheckboxText = ({ ...text }) => {
+  const isFloatRight = () => (text.link ? 'margin-left: auto;' : '');
   return `
       ${isFloatRight}
-      font-size: ${text.fontSize}px;
-      color: ${text.fontColor};
+      font-size: 0.875rem;
+      color: #4E4E4E;
   `;
 };
 
 export const StyledCheckbox = styled.div<SCheckboxComponentBox>`
-  display: flex;
-  flex-basis: auto;
-  align-items: center;
   ${getCheckboxBox}
 `;
 export const EmptyDiv = styled.div`
   display: flex;
   align-items: center;
 `;
-export const StyledCheckboxInput = styled.input<SCheckboxComponentInput>`
+export const StyledCheckboxInput = styled.input`
   width: 16px;
   height: 16px;
   border-radius: 4px;
-  ${getCheckboxInput};
+  accent-color: #4e4e4e;
 `;
 export const StyledCheckboxText = styled.div<SCheckboxComponentText>`
   padding-left: 1rem;


### PR DESCRIPTION
## 개요
체크박스 컴포넌트를 사용할때 객체 형식에 다수의 값을 프로퍼티로 넣어줘야하는 문제를 해결하며 코드 리팩토링을 진행하였습니다.
기존 Checkbox 예시 >>
```
<Checkbox box={width:300 height:30 backgroundColor:'#333333'}>
```

## 작업내용
### [변화내용]
#### 1.  args 항목 변경
` box:{}`, `input:{}`, `text:{}`처럼 argument로 객체를 받아 진행하는 방법에서 객체를 해체하고 argument값을 최소화하도록 변경하였습니다.
##### Argument변경
```typescript
// Before
box: {
    width: 300,
    height: 30,
    padding: '1.5px',
    backgroundColor: '#ffffff',
  },
  input: {
    backgroundColor: '#373737',
  },
  text: {
    fontSize: 12,
    fontColor: '#373737',
  },
};
// After
DefaultView.args = {
  label: '광고성 정보 수신 동의(선택)',
  link: false,
  width: '100px',
  height: '30px',
};
````

##### 2. CheckboxComponents해체
정리를 하고나니 checkboxComponent에 들어갈 값이 Box밖에 남지않아 이를 제거하였습니다.
```typescript
// Before
    <CheckboxComponents.Box {...box}>
      <EmptyDiv>
        <CheckboxComponents.Input {...input} />
        <CheckboxComponents.Text {...text}>{label}</CheckboxComponents.Text>
      </EmptyDiv>
      {link && <CheckboxComponents.Detail {...text}>보기</CheckboxComponents.Detail>}
    </CheckboxComponents.Box>

// After
    <StyledCheckbox {...box}>
      <EmptyDiv>
        <StyledCheckboxInput type={'checkbox'} />
        <StyledCheckboxText>{label}</StyledCheckboxText>
      </EmptyDiv>
      {link && <StyledCheckboxDetail>보기</StyledCheckboxDetail>}
    </StyledCheckbox>
```

##### 3. style.ts에서 SCheckboxComponet(Box, Input, Text) 및 StyledCheckboxComponent(Box, Input, Text) 간소화 
width, height, link만 각 컴포넌트에 맞게 남겨두고 나머지 항목을 제거하였습니다. 
```typescript
// Before
export interface SCheckboxComponentBox {
  width: number;
  height: number;
  padding: string;
  backgroundColor: string;
}
export interface SCheckboxComponentInput {
  backgroundColor: string;
}
export interface SCheckboxComponentText {
  fontSize: number;
  fontColor: string;
}

// After
export interface SCheckboxComponentBox {
  width?: string;
  height?: string;
}
export interface SCheckboxComponentText {
  link?: boolean;
}
```

### [결과]
#### Storybook 설정창
![image](https://user-images.githubusercontent.com/48820696/161490001-2c72243f-a1b4-4512-a0c9-9b4e9e15f898.png)
![image](https://user-images.githubusercontent.com/48820696/161490035-6e90327f-784b-4c18-aa34-035e7fc39edb.png)

#### Chromatic 주소
https://www.chromatic.com/build?appId=624819a68844fb003a06cdbc&number=9

## 주의사항
%와 px중에 상황에 맞게 사용하기 위해 box의 크기를 받을때 string으로 단위까지 입력하도록 하였습니다.
ex.
```
export const DefaultView = Template.bind({});
DefaultView.args = {
  label: '광고성 정보 수신 동의(선택)',
  link: false,
  width: '100px',
  height: '30px',
};
```