### PR TITLE
Create UI Normal Sign up Modal

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,12 @@
 import { SignInModal } from '../src/containers/SignInModal';
+import { NormalSignupModal } from '../src/containers/NormalSignupModal';
 
 const Home = () => {
   return <SignInModal />;
 };
 
-export default Home;
+const NormalSignupModalPage = () => {
+  return <NormalSignupModal />;
+};
+
+export default NormalSignupModalPage;

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -10,14 +10,15 @@ import {
 
 interface CheckBoxProps extends SCheckboxComponentBox, SCheckboxComponentText {
   label: string;
+  onClick?: () => void;
 }
 
-const Checkbox = ({ label, link, width = '100%', height = '30px' }: CheckBoxProps) => {
-  const box = { width, height };
+const Checkbox = ({ label, link, width = '100%', height = '30px', paddingLeft, onClick }: CheckBoxProps) => {
+  const box = { width, height, paddingLeft };
   return (
     <StyledCheckbox {...box}>
       <EmptyDiv>
-        <StyledCheckboxInput type={'checkbox'} />
+        <StyledCheckboxInput type={'checkbox'} onClick={onClick} />
         <StyledCheckboxText>{label}</StyledCheckboxText>
       </EmptyDiv>
       {link && <StyledCheckboxDetail>보기</StyledCheckboxDetail>}

--- a/src/components/Checkbox/style.ts
+++ b/src/components/Checkbox/style.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 export interface SCheckboxComponentBox {
   width?: string;
   height?: string;
+  paddingLeft?: string;
 }
 export interface SCheckboxComponentText {
   link?: boolean;
@@ -16,6 +17,7 @@ const getCheckboxBox = ({ ...box }) => {
     width: ${box.width};
     height: ${box.height};
     padding: 0.4rem;
+    padding-left : ${box.paddingLeft};
   `;
 };
 const getCheckboxText = ({ ...text }) => {

--- a/src/containers/NormalSignupModal.tsx
+++ b/src/containers/NormalSignupModal.tsx
@@ -1,0 +1,44 @@
+import Box from '../components/Box';
+import Button from '../components/Button';
+import Checkbox from '../components/Checkbox';
+import Input from '../components/Input';
+import Typography from '../components/Typography';
+import Wrapper from '../components/Wrapper';
+
+export const NormalSignupModal = () => (
+  <Box width={500} height={800}>
+    <Wrapper flexDirection={'row'} rowInterval={20}>
+      <Typography size={'lg'} color={'black'} weight={'BOLD'}>
+        🌳 간편 가입하기
+      </Typography>
+      <Wrapper flexDirection={'column'} rowInterval={15}>
+        <Typography size={'lg'} color={'darkgray'}>
+          인생선배를 찾는 지름길,
+        </Typography>
+        <Typography size={'lg'} color={'darkgray'}>
+          그루터기
+        </Typography>
+      </Wrapper>
+      <Wrapper flexDirection={'column'} interval={20}>
+        <Input width={375} height={40} placeholder={'이메일'} />
+        <Wrapper flexDirection={'row'} columnInterval={1} justifyContent={'flex-end'}>
+          <Button color={'black'} fontColor={'white'} borderColor={'none'} name={'이메일 인증'} size={'md'} />
+        </Wrapper>
+      </Wrapper>
+      <Wrapper flexDirection={'column'} rowInterval={20}>
+        <Input width={375} height={40} placeholder={'비밀번호'}></Input>
+        <Input width={375} height={40} placeholder={'비밀번호 확인'}></Input>
+        <Wrapper flexDirection={'row'} rowInterval={5}>
+          <Checkbox label={'전체 동의'}></Checkbox>
+          <Wrapper flexDirection={'row'} rowInterval={10}>
+            <Checkbox label={'서비스 이용 약관 동의 (필수)'} link={true} paddingLeft={'1rem'}></Checkbox>
+            <Checkbox label={'개인정보 수집 및 이용 동의 (필수)'} link={true} paddingLeft={'1rem'}></Checkbox>
+            <Checkbox label={'만 14세 이상입니다 (필수)'} paddingLeft={'1rem'}></Checkbox>
+            <Checkbox label={'광고성 정보 수신 동의 (선택)'} link={true} paddingLeft={'1rem'}></Checkbox>
+          </Wrapper>
+        </Wrapper>
+      </Wrapper>
+      <Button color={'white'} name={'회원가입하기'} fontColor={'black'} size={'lg'}></Button>
+    </Wrapper>
+  </Box>
+);

--- a/src/containers/NormalSignupModal/index.stories.tsx
+++ b/src/containers/NormalSignupModal/index.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import GlobalThemeProvider from '../../../styles/GlobalThemeProvider';
+import theme from '../../../styles/theme';
+import { NormalSignupModal } from './index';
+
+export default {
+  title: 'Containers/NormalSignupModal',
+  component: NormalSignupModal,
+} as ComponentMeta<typeof NormalSignupModal>;
+
+const Template: ComponentStory<typeof NormalSignupModal> = () => (
+  <GlobalThemeProvider theme={theme}>
+    <NormalSignupModal />
+  </GlobalThemeProvider>
+);
+
+export const BoxWrapper = Template.bind({});
+BoxWrapper.args = {
+  flexDirection: 'row',
+};

--- a/src/containers/NormalSignupModal/index.stories.tsx
+++ b/src/containers/NormalSignupModal/index.stories.tsx
@@ -15,6 +15,3 @@ const Template: ComponentStory<typeof NormalSignupModal> = () => (
 );
 
 export const BoxWrapper = Template.bind({});
-BoxWrapper.args = {
-  flexDirection: 'row',
-};

--- a/src/containers/NormalSignupModal/index.stories.tsx
+++ b/src/containers/NormalSignupModal/index.stories.tsx
@@ -14,4 +14,4 @@ const Template: ComponentStory<typeof NormalSignupModal> = () => (
   </GlobalThemeProvider>
 );
 
-export const BoxWrapper = Template.bind({});
+export const DefaultNormalSignup = Template.bind({});

--- a/src/containers/NormalSignupModal/index.tsx
+++ b/src/containers/NormalSignupModal/index.tsx
@@ -1,9 +1,9 @@
-import Box from '../components/Box';
-import Button from '../components/Button';
-import Checkbox from '../components/Checkbox';
-import Input from '../components/Input';
-import Typography from '../components/Typography';
-import Wrapper from '../components/Wrapper';
+import Box from '../../components/Box';
+import Button from '../../components/Button';
+import Checkbox from '../../components/Checkbox';
+import Input from '../../components/Input';
+import Typography from '../../components/Typography';
+import Wrapper from '../../components/Wrapper';
 
 export const NormalSignupModal = () => (
   <Box width={500} height={800}>
@@ -38,7 +38,7 @@ export const NormalSignupModal = () => (
           </Wrapper>
         </Wrapper>
       </Wrapper>
-      <Button color={'white'} name={'회원가입하기'} fontColor={'black'} size={'lg'}></Button>
+      <Button color={'primary'} name={'회원가입하기'} fontColor={'black'} size={'lg'}></Button>
     </Wrapper>
   </Box>
 );


### PR DESCRIPTION
## 개요
Normal Signup Modal을 만들었습니다.

## 작업내용
### Normal Signup Modal 생성
기존에 만들어뒀던 Component들을 사용하여 Normal Sign up Modal을 만들었습니다.
#### <web 기준 화면>
![image](https://user-images.githubusercontent.com/48820696/162124754-708af5b7-c0ff-4dcb-9bd3-739237923651.png)
#### <iphone 12 pro 기준 화면>
![image](https://user-images.githubusercontent.com/48820696/162124822-90657ea6-95cf-46aa-99a0-1b755b3add92.png)

## 주의사항
Wrapper의 padding-bottom : 2rem이 지웠을때 정상적으로 작동이 이뤄집니다.

