### PR TITLE
Change Header Props and style

### DIFF
--- a/src/components/Header/index.stories.tsx
+++ b/src/components/Header/index.stories.tsx
@@ -14,29 +14,8 @@ const Template: ComponentStory<typeof Header> = args => (
   </GlobalThemeProvider>
 );
 
-const Common = Template.bind({});
-Common.args = {
-  navLists: [
-    { value: '🌳그루터기', isLogo: true, leftPosition: true },
-    { value: '약속 잡기', leftPosition: true },
-    { value: '약속 찾기', leftPosition: true },
-    { value: '채팅', isAuth: true },
-    { value: '내정보', isAuth: true },
-    { value: '로그아웃', isAuth: true },
-    { value: '로그인', isAuth: false },
-  ],
-};
 export const Signin = Template.bind({});
 Signin.args = {
-  navLists: [
-    { value: '🌳그루터기', isLogo: true, leftPosition: true },
-    { value: '약속 잡기', leftPosition: true },
-    { value: '약속 찾기', leftPosition: true },
-    { value: '채팅', isAuth: true },
-    { value: '내정보', isAuth: true },
-    { value: '로그아웃', isAuth: true },
-    { value: '로그인', isAuth: false },
-  ],
   device: 'md' as const,
   user: {
     name: 'test User',
@@ -44,14 +23,16 @@ Signin.args = {
 };
 export const Signout = Template.bind({});
 Signout.args = {
-  navLists: [
-    { value: '🌳그루터기', isLogo: true, leftPosition: true },
-    { value: '약속 잡기', leftPosition: true },
-    { value: '약속 찾기', leftPosition: true },
-    { value: '채팅', isAuth: true },
-    { value: '내정보', isAuth: true },
-    { value: '로그아웃', isAuth: true },
-    { value: '로그인', isAuth: false },
-  ],
   device: 'md' as const,
+};
+export const MobileSignin = Template.bind({});
+MobileSignin.args = {
+  device: 'sm' as const,
+  user: {
+    name: 'test User',
+  },
+};
+export const MobileSignout = Template.bind({});
+MobileSignout.args = {
+  device: 'sm' as const,
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,12 +11,21 @@ export type NavList = {
   leftPosition?: boolean;
 };
 
+const navLists = [
+  { value: '🌳그루터기', isLogo: true, leftPosition: true },
+  { value: '약속 잡기', leftPosition: true },
+  { value: '약속 찾기', leftPosition: true },
+  { value: '채팅', isAuth: true },
+  { value: '내정보', isAuth: true },
+  { value: '로그아웃', isAuth: true },
+  { value: '로그인', isAuth: false },
+];
+
 interface HeaderProps extends SHeaderDevice {
   user?: User;
-  navLists: NavList[];
 }
 
-const HeaderList = ({ device, navList }: { device: 'sm' | 'md' | 'lg'; navList: NavList }) => {
+const HeaderList = ({ device, navList }: { device: 'sm' | 'md'; navList: NavList }) => {
   if (!navList.isLogo) navList.isLogo = false;
   if (!navList.leftPosition) navList.leftPosition = false;
   const headerListProps = { device: device, leftPosition: navList.leftPosition };
@@ -30,7 +39,7 @@ const HeaderList = ({ device, navList }: { device: 'sm' | 'md' | 'lg'; navList: 
   );
 };
 
-const Header = ({ user, device, navLists }: HeaderProps) => {
+const Header = ({ user, device }: HeaderProps) => {
   return (
     <StyledHeader>
       <StyledHeaderBox>

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -5,7 +5,7 @@ import theme from '../../../styles/theme';
 const headerTheme = theme.style.header;
 
 export type SHeaderDevice = {
-  device: 'sm' | 'md' | 'lg';
+  device: 'sm' | 'md';
 };
 
 export interface SHeaderAnchor extends SHeaderDevice {
@@ -33,6 +33,10 @@ const getFont = ({ device, isLogo }: SHeaderAnchor) => {
   `;
 };
 
+const getPadding = ({ device }: SHeaderDevice) => {
+  return `padding: ${headerTheme.padding[device]}`;
+};
+
 export const StyledHeader = styled.div`
   background-color: white;
   display: flex;
@@ -46,13 +50,13 @@ export const StyledHeaderBox = styled.div`
   ${getHeaderBoxStyle};
 `;
 
-export const StyledHeaderList = styled.div`
+export const StyledHeaderList = styled.div<SHeaderDevice>`
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
   align-items: center;
   height: 100%;
-  padding: 1rem;
+  ${getPadding};
   cursor: pointer;
   &:hover,
   &:active {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -118,14 +118,16 @@ const style = {
   },
   header: {
     fontSizeBasic: {
-      sm: 'x-small',
-      md: 'smaller',
-      lg: 'medium',
+      sm: '0.65rem',
+      md: '0.8rem',
     },
     fontSizeLogo: {
-      sm: 'smaller',
-      md: 'small',
-      lg: 'medium',
+      sm: '0.8rem',
+      md: '1rem',
+    },
+    padding: {
+      sm: '0.6rem',
+      md: '1rem',
     },
   },
   sortingTab: {


### PR DESCRIPTION
## 개요
Header를 사용할때마다 안의 항목들을 넣는게 불필요한 일이라 생각하여 글씨 및 간격을 조절하는 `device`와 로그인 여부인 `user`만을 props로 사용하도록 변경하였습니다.

### Chromatic
https://www.chromatic.com/component?appId=624819a68844fb003a06cdbc&csfId=components-header&buildNumber=26&k=625333fa2fa940003abb07d8-1200-interactive-true&h=2&b=-1

## 작업내용
### 1) 공통적으로 사용되는 navLists를 index.tsx로 이동
args마다 넣어주던 navLists를 index.tsx에서 선언하여 불필요한 props를 제거하였습니다.
#### index.stories.tsx
```typescript
// before -> 불필요하게 길다...
export const Signin = Template.bind({});
Signin.args = {
  navLists: [
    { value: '🌳그루터기', isLogo: true, leftPosition: true },
    { value: '약속 잡기', leftPosition: true },
    { value: '약속 찾기', leftPosition: true },
    { value: '채팅', isAuth: true },
    { value: '내정보', isAuth: true },
    { value: '로그아웃', isAuth: true },
    { value: '로그인', isAuth: false },
  ],
  device: 'md' as const,
  user: {
    name: 'test User',
  },
};
export const Signout = Template.bind({});
Signout.args = {
  navLists: [
    { value: '🌳그루터기', isLogo: true, leftPosition: true },
    { value: '약속 잡기', leftPosition: true },
    { value: '약속 찾기', leftPosition: true },
    { value: '채팅', isAuth: true },
    { value: '내정보', isAuth: true },
    { value: '로그아웃', isAuth: true },
    { value: '로그인', isAuth: false },
  ],
  device: 'md' as const,
};
// after -> 짧다
export const Signin = Template.bind({});
Signin.args = {
  device: 'md' as const,
  user: {
    name: 'test User',
  },
};
export const Signout = Template.bind({});
Signout.args = {
  device: 'md' as const,
};
```

### 2) theme.style.header의 변경
모바일 모드로 변경하였을 때 로그인 상태의 경우 글씨가 어긋나는 문제를 발견하여 theme.style.header에 정의된 fontSize를 변경하였습니다.
```typescript
// before
    fontSizeBasic: {
      sm: 'x-small',
      md: 'smaller',
      lg: 'medium',
    },
    fontSizeLogo: {
      sm: 'smaller',
      md: 'small',
      lg: 'medium',
    },
// after
    fontSizeBasic: {
      sm: '0.65rem',
      md: '0.8rem',
    },
    fontSizeLogo: {
      sm: '0.8rem',
      md: '1rem',
    },
```

또한, 모바일 모드에서까지 1rem의 padding을 부여하는 것은 불필요하다 생각하여 padding에 대한  theme.style도 추가하였습니다.
```typescript
    padding: {
      sm: '0.6rem',
      md: '1rem',
    },
```

### 3) device 사이즈의 단축
sm, md, lg로 나눠 사용하던 device사이즈를 sm, md만 남겨 모바일의 경우 `sm`, 데스크탑의 경우 `md`를 사용하도록 변경하였으니 사용에 유의하시길 바랍니다!
```typescript
export type SHeaderDevice = {
  device: 'sm' | 'md';
};
```
#### sm (모바일)
- user O
![image](https://user-images.githubusercontent.com/48820696/162636969-7ff9d682-e219-4548-9938-8053dbb6c2fc.png)

- user X
![image](https://user-images.githubusercontent.com/48820696/162636954-c7aed00a-d85d-4cbd-9cd6-42a5e488acdc.png)

#### md (데스크탑)
- user O
![image](https://user-images.githubusercontent.com/48820696/162636870-0df42fb7-0e30-4159-b3da-12283d6b58f2.png)

- user X
![image](https://user-images.githubusercontent.com/48820696/162636884-19010262-c993-47b7-b150-31771addd02a.png)


## 주의사항
변경 사항의 `3) device 사이즈의 단축`을 유의하시면 좋을 것 같습니다!
