### PR TITLE
feat: Create Image component

### DIFF
--- a/components/common/Image/Image.stories.tsx
+++ b/components/common/Image/Image.stories.tsx
@@ -1,0 +1,51 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import GlobalThemeProvider from '@styles/GlobalThemeProvider';
+import theme from '@styles/theme';
+import Image from './index';
+
+export default {
+  title: 'Components/Image',
+  component: Image,
+} as ComponentMeta<typeof Image>;
+
+const Template: ComponentStory<typeof Image> = ({ ...args }) => (
+  <GlobalThemeProvider theme={theme}>
+    <div style={{ backgroundColor: '#eeeeee' }}>
+      <Image {...args} />
+    </div>
+  </GlobalThemeProvider>
+);
+
+export const ContainWidthImage = Template.bind({});
+ContainWidthImage.args = {
+  width: '500px',
+  height: '500px',
+  objectFit: 'contain',
+  src: '/imgs/CarouselBasic.png',
+  alt: 'not found',
+};
+export const ContainHeightImage = Template.bind({});
+ContainHeightImage.args = {
+  width: '500px',
+  height: '500px',
+  objectFit: 'contain',
+  src: '/imgs/RotatedImg.png',
+  alt: 'not found',
+};
+
+export const CoverImage = Template.bind({});
+CoverImage.args = {
+  width: '500px',
+  height: '500px',
+  objectFit: 'cover',
+  src: '/imgs/RotatedImg.png',
+  alt: 'not found',
+};
+export const FillImage = Template.bind({});
+FillImage.args = {
+  width: '500px',
+  height: '500px',
+  objectFit: 'fill',
+  src: '/imgs/RotatedImg.png',
+  alt: 'not found',
+};

--- a/components/common/Image/Image.stories.tsx
+++ b/components/common/Image/Image.stories.tsx
@@ -43,8 +43,6 @@ CoverImage.args = {
 };
 export const FillImage = Template.bind({});
 FillImage.args = {
-  width: '500px',
-  height: '500px',
   objectFit: 'fill',
   src: '/imgs/RotatedImg.png',
   alt: 'not found',

--- a/components/common/Image/Image.stories.tsx
+++ b/components/common/Image/Image.stories.tsx
@@ -10,40 +10,28 @@ export default {
 
 const Template: ComponentStory<typeof Image> = ({ ...args }) => (
   <GlobalThemeProvider theme={theme}>
-    <div style={{ backgroundColor: '#eeeeee' }}>
+    <div style={{ width: '500px', height: '500px', backgroundColor: '#eeeeee' }}>
       <Image {...args} />
     </div>
   </GlobalThemeProvider>
 );
 
-export const ContainWidthImage = Template.bind({});
-ContainWidthImage.args = {
-  width: '500px',
-  height: '500px',
-  objectFit: 'contain',
-  src: '/imgs/CarouselBasic.png',
+export const LargeWidthImage = Template.bind({});
+LargeWidthImage.args = {
+  src: '/imgs/Carousel2.png',
   alt: 'not found',
+  size: 'lg',
 };
-export const ContainHeightImage = Template.bind({});
-ContainHeightImage.args = {
-  width: '500px',
-  height: '500px',
-  objectFit: 'contain',
-  src: '/imgs/RotatedImg.png',
+export const MediumHeightImage = Template.bind({});
+MediumHeightImage.args = {
+  src: '/imgs/Carousel2.png',
   alt: 'not found',
+  size: 'md',
 };
 
-export const CoverImage = Template.bind({});
-CoverImage.args = {
-  width: '500px',
-  height: '500px',
-  objectFit: 'cover',
-  src: '/imgs/RotatedImg.png',
+export const SmallHeightImage = Template.bind({});
+SmallHeightImage.args = {
+  src: '/imgs/Carousel2.png',
   alt: 'not found',
-};
-export const FillImage = Template.bind({});
-FillImage.args = {
-  objectFit: 'fill',
-  src: '/imgs/RotatedImg.png',
-  alt: 'not found',
+  size: 'sm',
 };

--- a/components/common/Image/Image.styled.ts
+++ b/components/common/Image/Image.styled.ts
@@ -1,15 +1,33 @@
 import styled from '@emotion/styled';
 
 export interface StyledImageProps {
-  width?: string;
-  height?: string;
-  objectFit: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
+  size: 'lg' | 'md' | 'sm';
 }
-
+const getSize = ({ size }: StyledImageProps) => {
+  if (size === 'lg')
+    return `
+    @media (max-width: 767px) {
+      width: 180px;
+      height: 150px;
+    }
+    width: 235px;
+    height: 200px;
+  `;
+  if (size === 'md')
+    return `
+    width: 132px;
+    height: 132px;
+  `;
+  if (size === 'sm')
+    return `
+    width: 100px;
+    height: 100px;
+  `;
+};
 export const Styled = {
   image: styled.img<StyledImageProps>`
-    width: ${props => (props.width ? props.width : '100%')};
-    height: ${props => (props.height ? props.height : '100%')};
-    object-fit: ${props => props.objectFit};
+    ${getSize}
+    object-fit: cover;
+    object-position: 50% 50%;
   `,
 };

--- a/components/common/Image/Image.styled.ts
+++ b/components/common/Image/Image.styled.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export interface imageProps {
+  width: string;
+  height: string;
+  objectFit: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
+}
+
+export const Styled = {
+  image: styled.img<imageProps>`
+    width: ${props => props.width};
+    height: ${props => props.height};
+    object-fit: ${props => props.objectFit};
+  `,
+};

--- a/components/common/Image/Image.styled.ts
+++ b/components/common/Image/Image.styled.ts
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
-export interface imageProps {
+export interface StyledImageProps {
   width: string;
   height: string;
   objectFit: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
 }
 
 export const Styled = {
-  image: styled.img<imageProps>`
+  image: styled.img<StyledImageProps>`
     width: ${props => props.width};
     height: ${props => props.height};
     object-fit: ${props => props.objectFit};

--- a/components/common/Image/Image.styled.ts
+++ b/components/common/Image/Image.styled.ts
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled';
 
 export interface StyledImageProps {
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   objectFit: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
 }
 
 export const Styled = {
   image: styled.img<StyledImageProps>`
-    width: ${props => props.width};
-    height: ${props => props.height};
+    width: ${props => (props.width ? props.width : '100%')};
+    height: ${props => (props.height ? props.height : '100%')};
     object-fit: ${props => props.objectFit};
   `,
 };

--- a/components/common/Image/Image.tsx
+++ b/components/common/Image/Image.tsx
@@ -6,7 +6,7 @@ interface ImageProps extends StyledImageProps {
   alt?: string;
 }
 
-const Image: React.FC<ImageProps> = ({ src, alt, width, height, objectFit }) => {
-  return <Styled.image src={src} alt={alt} width={width} height={height} objectFit={objectFit} />;
+const Image: React.FC<ImageProps> = ({ src, alt, size }) => {
+  return <Styled.image src={src} alt={alt} size={size} />;
 };
 export default Image;

--- a/components/common/Image/Image.tsx
+++ b/components/common/Image/Image.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { imageProps, Styled } from './Image.styled';
+
+interface ImageProps extends imageProps {
+  src: string;
+  alt?: string;
+}
+
+const Image: React.FC<ImageProps> = ({ src, alt, width, height, objectFit }) => {
+  return <Styled.image src={src} alt={alt} width={width} height={height} objectFit={objectFit} />;
+};
+export default Image;

--- a/components/common/Image/Image.tsx
+++ b/components/common/Image/Image.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { imageProps, Styled } from './Image.styled';
+import { StyledImageProps, Styled } from './Image.styled';
 
-interface ImageProps extends imageProps {
+interface ImageProps extends StyledImageProps {
   src: string;
   alt?: string;
 }

--- a/components/common/Image/index.tsx
+++ b/components/common/Image/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Image';


### PR DESCRIPTION
## 개요
재사용을 위한 이미지 컴포넌트 제작

## 작업내용
이미지 display type을 지정할 수 있도록 제작함.
```
objectFit: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
```

fill: This is default. The image is resized to fill the given dimension. If necessary, the image will be stretched or squished to fit
기본값임. 주어진 너비 높이에 맞춰서 사이즈 조정됨. 필요할 경우 이미지가 스트레치(사이즈가 늘려짐)되거나 좁혀짐.

contain: The image keeps its aspect ratio, but is resized to fit within the given dimension
이미지의 기본 비율을 유지하면서 주어진 너비 높이에 맞추기 위해 사이즈가 조절됨 (수정씨 구현 내용)

cover: The image keeps its aspect ratio and fills the given dimension. The image will be clipped to fit
이미지의 기본 비율을 유지하면서 주어진 너비와 높이를 채워서 보여줌. 주어진 너비를 벗어나는 부분은 보여지지 않음

none: The image is not resized.
이미지 사이즈 조절 없음

scale-down: the image is scaled down to the smallest version of none or contain
contain 또는 none에 맞춰서 이미지의 스케일을 저하시킴

출처: https://www.w3schools.com/css/css3_object-fit.asp

## 주의사항
이미지 태그만 반환하도록 했으니 contain 에 필요한 여백 부분은 다른 컨테이터 컴포넌트로 감싸줘야함