### PR TITLE
refactor: button menu is for single click, buttons do not have clicke…

### DIFF
--- a/components/common/SearchBar/SearchBar.stories.tsx
+++ b/components/common/SearchBar/SearchBar.stories.tsx
@@ -17,14 +17,9 @@ const Template: ComponentStory<typeof SearchBar> = args => (
 export const DefaultInput = Template.bind({});
 DefaultInput.args = {
   placeholder: '관심사를 검색해보세요~',
-  hashtags: [],
 };
 
 export const HashInput = Template.bind({});
 HashInput.args = {
   placeholder: '관심사를 검색해보세요~',
-  hashtags: [
-    { id: 1, hashtagType: 'CONCERN', tag: '대학생활', registered: '' },
-    { id: 2, hashtagType: 'CONCERN', tag: '대외활동', registered: '' },
-  ],
 };

--- a/components/common/SearchBar/SearchBar.tsx
+++ b/components/common/SearchBar/SearchBar.tsx
@@ -19,10 +19,7 @@ type fetchedDataType = {
 };
 
 interface InputProps {
-  type?: string;
-  value?: string;
   placeholder?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const SearchBar: React.FC<InputProps> = ({ placeholder }) => {

--- a/components/common/SearchBar/SearchBar.tsx
+++ b/components/common/SearchBar/SearchBar.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import { Styled } from './SearchBar.styled';
 import Typography from '@components/common/Typography';
-import Hashtag from '@components/common/Hashtag';
-import { fetchedHashtag } from 'types/fetchedHashtag';
 
 const fetchedData = [
   { keyword: '대외활동' },
@@ -25,10 +23,9 @@ interface InputProps {
   value?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  hashtags: fetchedHashtag[];
 }
 
-const SearchBar: React.FC<InputProps> = ({ hashtags, placeholder }) => {
+const SearchBar: React.FC<InputProps> = ({ placeholder }) => {
   const [filteredData, setFilteredData] = useState<fetchedDataType[]>([]);
   const [wordEntered, setWordEntered] = useState<string>('');
 
@@ -48,9 +45,6 @@ const SearchBar: React.FC<InputProps> = ({ hashtags, placeholder }) => {
   return (
     <Styled.container>
       <Styled.section>
-        {hashtags.map(hashtag => {
-          return <Hashtag key={hashtag.id} fetchedTag={hashtag} />;
-        })}
         <Styled.input type={'text'} value={wordEntered} onChange={handleFilter} placeholder={placeholder} />
         <Image src={'/logos/search.png'} alt={'search icon not found'} width={'16px'} height={'16px'} />
       </Styled.section>

--- a/components/common/SearchButton/SearchButton.stories.tsx
+++ b/components/common/SearchButton/SearchButton.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import GlobalThemeProvider from '@styles/GlobalThemeProvider';
 import theme from '@styles/theme';
+import { useState } from 'react';
 import SearchButton from './index';
 
 export default {
@@ -13,10 +14,41 @@ const Template: ComponentStory<typeof SearchButton> = args => (
     <SearchButton {...args} />
   </GlobalThemeProvider>
 );
-export const Default = (args: ComponentStory<typeof SearchButton>) => {
+export const Clicked = (args: ComponentStory<typeof SearchButton>) => {
   return (
     <GlobalThemeProvider theme={theme}>
-      <Template fetchedTag={{ id: 1, hashtagType: 'CONCERN', tag: '#sample', registered: '' }} {...args} />
+      <Template
+        fetchedTag={{
+          id: 0,
+          hashtagType: 'PERSONALITY',
+          tag: 'sample tag',
+          registered: '',
+          count: 1,
+        }}
+        clicked={true}
+        setClickedButtonId={function doNothing() {
+          return;
+        }}
+      />
+    </GlobalThemeProvider>
+  );
+};
+export const NotClicked = (args: ComponentStory<typeof SearchButton>) => {
+  return (
+    <GlobalThemeProvider theme={theme}>
+      <Template
+        fetchedTag={{
+          id: 0,
+          hashtagType: 'PERSONALITY',
+          tag: 'sample tag',
+          registered: '',
+          count: 1,
+        }}
+        clicked={false}
+        setClickedButtonId={function doNothing() {
+          return;
+        }}
+      />
     </GlobalThemeProvider>
   );
 };

--- a/components/common/SearchButton/SearchButton.tsx
+++ b/components/common/SearchButton/SearchButton.tsx
@@ -1,20 +1,19 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ButtonProps, Styled } from './SearchButton.styled';
 import Typography from '@components/common/Typography';
 import { fetchedHashtag } from 'types/fetchedHashtag';
 
 interface SearchButtonProp extends ButtonProps {
   fetchedTag: fetchedHashtag;
-  onClick?: (hashtag: fetchedHashtag, clicked: boolean) => void;
+  clicked: boolean;
+  setClickedButtonId: (hashtagId: number) => void;
 }
 
-const SearchButton: React.FC<SearchButtonProp> = ({ fetchedTag, onClick }) => {
-  const [clicked, setClicked] = useState<boolean>(false);
+const SearchButton: React.FC<SearchButtonProp> = ({ fetchedTag, clicked, setClickedButtonId }) => {
   return (
     <Styled.button
       onClick={() => {
-        onClick && onClick(fetchedTag, clicked);
-        setClicked(!clicked);
+        setClickedButtonId(fetchedTag.id);
       }}
       clicked={clicked}
     >

--- a/components/common/SearchMenu/SearchMenu.tsx
+++ b/components/common/SearchMenu/SearchMenu.tsx
@@ -6,10 +6,11 @@ import { fetchedHashtag } from 'types/fetchedHashtag';
 
 interface SearchMenuProps {
   data: fetchedHashtag[];
-  onClick: (hashtag: fetchedHashtag, clicked: boolean) => void;
+  clickedButtonId: number;
+  setClickedButtonId: (hashtagId: number) => void;
 }
 
-const SearchMenu: React.FC<SearchMenuProps> = ({ data, onClick }) => {
+const SearchMenu: React.FC<SearchMenuProps> = ({ data, clickedButtonId, setClickedButtonId }) => {
   const hScroll = useRef<any>();
   const [slideLeft, setSlideLeft] = useState<number>(0);
   const [hideButtonLeft, setHideButtonLeft] = useState<boolean>(true);
@@ -38,7 +39,14 @@ const SearchMenu: React.FC<SearchMenuProps> = ({ data, onClick }) => {
     <Styled.container>
       <Styled.horizontalScroll ref={hScroll} onScroll={onHScroll}>
         {data.map(hash => {
-          return <SearchButton key={hash.id} fetchedTag={hash} onClick={onClick} />;
+          return (
+            <SearchButton
+              fetchedTag={hash}
+              clicked={clickedButtonId === hash.id}
+              setClickedButtonId={setClickedButtonId}
+              key={hash.id}
+            />
+          );
         })}
       </Styled.horizontalScroll>
       {slideLeft > 0 ? <LeftArrow onClick={moveLeft} hideButton={hideButtonLeft} /> : <></>}

--- a/components/post/MeetingInfoEdit/MeetingInfoEdit.tsx
+++ b/components/post/MeetingInfoEdit/MeetingInfoEdit.tsx
@@ -67,7 +67,7 @@ const MeetingInfoEdit: React.FC<MeetingInfoEditProps> = ({ title, content, image
         <Typography size={'lg'} color={'black'} weight={'BOLD'}>
           저는 이런 분야에 관심이 있어요
         </Typography>
-        <SearchBar hashtags={[]}></SearchBar>
+        <SearchBar />
         <Wrapper flexDirection={'row'} gap={{ columnGap: 20 }}>
           {hashtags.map(({ ...el }) => (
             <Hashtag key={el.id} fetchedTag={el} removable onRemove={() => onRemove(el.id)}></Hashtag>

--- a/components/search/SearchPage.tsx
+++ b/components/search/SearchPage.tsx
@@ -18,13 +18,7 @@ const tagsForCards: fetchedHashtag[] = [
 ];
 
 const SearchPage = () => {
-  const [selectedTags, setSelectedTags] = useState<fetchedHashtag[]>([]);
-
-  const onHashtagClick = (hashtag: fetchedHashtag, clicked: boolean) => {
-    clicked
-      ? setSelectedTags(selectedTags.filter(tag => tag.id !== hashtag.id))
-      : setSelectedTags([...selectedTags, hashtag]);
-  };
+  const [clickedButtonId, setClickedButtonId] = useState<number>(-1);
 
   const imgLists = [
     {
@@ -54,8 +48,12 @@ const SearchPage = () => {
     <Content>
       <Wrapper flexDirection={'column'} alignItems={'center'} gap={{ gap: 50 }}>
         <Carousel imgLists={imgLists} />
-        <SearchBar hashtags={selectedTags} />
-        <SearchMenu data={tempButtons as fetchedHashtag[]} onClick={onHashtagClick} />
+        <SearchBar />
+        <SearchMenu
+          data={tempButtons as fetchedHashtag[]}
+          clickedButtonId={clickedButtonId}
+          setClickedButtonId={setClickedButtonId}
+        />
       </Wrapper>
       <Wrapper
         flexDirection={'row'}


### PR DESCRIPTION
## 개요
버튼 메뉴가 클릭 로직 변경, 버튼은 하나만 클릭 가능

## 작업내용
SearchPage
페이지에서 클릭한 버튼의 id값을 가지고있음. 초기값은 -1
`
const [clickedButtonId, setClickedButtonId] = useState<number>(-1);
`

SearchMenu
```
{data.map(hash => {
          return (
            <SearchButton
              fetchedTag={hash}
              clicked={clickedButtonId === hash.id}
              setClickedButtonId={setClickedButtonId}
              key={hash.id}
            />
          );
        })}
```
클릭한 값이 해당 버튼과 같은 내용인지 hashtag의 id를 통해 비교함

SearchButton
```
<Styled.button
      onClick={() => {
        setClickedButtonId(fetchedTag.id);
      }}
      clicked={clicked}
    >
```
SearchButton 컴포넌트에 page에서 관리중인 setClickedButtonId를 param으로 전달해 onClick를 통해 변경.

## 주의사항
수평 스크롤 뒤 쪽에 있는 버튼 클릭시 스크롤이 앞으로 돌아오는 버그는 고칠 예정