### PR TITLE
CI Task에 빌드 추가

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -26,12 +26,16 @@ jobs:
         run: yarn format
       - name: Build
         run: yarn build
+        env:
+          SERVER_URL: ${{ secrets.SERVER_URL }}
+          NEXT_PUBLIC_KAKAO_AUTH: ${{ secrets.NEXT_PUBLIC_KAKAO_AUTH }}
+          NEXT_PUBLIC_GOOGLE_AUTH: ${{ secrets.NEXT_PUBLIC_GOOGLE_AUTH }}
       - name: Notify Result
         uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
           author_name: Pull request Test Result
           fields: repo, message, commit, author, eventName, workflow
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -24,3 +24,5 @@ jobs:
         run: yarn lint
       - name: Format
         run: yarn format
+      - name: Build
+        run: yarn build

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -31,11 +31,11 @@ jobs:
           NEXT_PUBLIC_KAKAO_AUTH: ${{ secrets.NEXT_PUBLIC_KAKAO_AUTH }}
           NEXT_PUBLIC_GOOGLE_AUTH: ${{ secrets.NEXT_PUBLIC_GOOGLE_AUTH }}
       - name: Notify Result
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: 8398a7/action-slack@v3.13.0
         with:
           status: ${{ job.status }}
           author_name: Pull request Test Result
           fields: repo, message, commit, author, eventName, workflow
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -26,3 +26,12 @@ jobs:
         run: yarn format
       - name: Build
         run: yarn build
+      - name: Notify Result
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Pull request Test Result
+          fields: repo, message, commit, author, eventName, workflow
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           status: ${{ job.status }}
           author_name: Pull request Test Result
-          fields: repo, message, commit, author, eventName, workflow
+          fields: repo, pullRequest, eventName, workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()


### PR DESCRIPTION
## 개요
풀리퀘스트 테스트 시 빌드 진행
기존에는 Vercel의 빌드 결과를 관리자만 볼 수 있었음 -> 깃헙 액션을 통해 빌드 과정을 볼 수 있도록 구성

## 작업내용
- workflow에 빌드 추가

## 주의사항
빌드 때문에 테스트 시간이 늘어날 수 있습니다.
