### PR TITLE
CI Task에 빌드 및 슬랙봇 추가

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,33 @@
+name: Build Test
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build
+        run: yarn build
+        env:
+          SERVER_URL: ${{ secrets.SERVER_URL }}
+          NEXT_PUBLIC_KAKAO_AUTH: ${{ secrets.NEXT_PUBLIC_KAKAO_AUTH }}
+          NEXT_PUBLIC_GOOGLE_AUTH: ${{ secrets.NEXT_PUBLIC_GOOGLE_AUTH }}
+      - name: If fail
+        uses: peter-evans/commit-comment@v2
+        with:
+          sha: ${{ github.sha }}
+          body: |
+            @${{ github.actor }} 다시 확인 부탁드립니다!
+        if: failure()


### PR DESCRIPTION
## 개요
풀리퀘스트 테스트 시 빌드 진행 및 테스트 결과를 슬랙봇이 알려줄 수 있도록 구성함.
기존에는 Vercel의 빌드 결과를 관리자만 볼 수 있었음 -> 깃헙 액션을 통해 빌드 과정을 볼 수 있도록 구성

## 작업내용
- workflow에 빌드 추가
- 슬랙봇 추가

## 주의사항
빌드 때문에 테스트 시간이 늘어날 수 있습니다.
