### PR TITLE
Create Footer Component

### DIFF
--- a/components/common/Footer/Footer.stories.tsx
+++ b/components/common/Footer/Footer.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import GlobalThemeProvider from '@styles/GlobalThemeProvider';
+import theme from '@styles/theme';
+import Footer from './index';
+
+export default {
+  title: 'Components/Footer',
+  component: Footer,
+} as ComponentMeta<typeof Footer>;
+
+const Template: ComponentStory<typeof Footer> = args => (
+  <GlobalThemeProvider theme={theme}>
+    <Footer {...args} />
+  </GlobalThemeProvider>
+);
+
+export const Default = Template.bind({});

--- a/components/common/Footer/Footer.styled.ts
+++ b/components/common/Footer/Footer.styled.ts
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import theme from '@styles/theme';
+
+const Styled = {
+  footer: styled.footer`
+    width: 100vw;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    background: ${theme.color.deepdarkgray};
+  `,
+  paragraph: styled.div`
+    color: ${theme.color.white};
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 2rem auto;
+    @media (min-width: 1060px) {
+      width: 1060px;
+    }
+    @media (min-width: 768px) and (max-width: 1059px) {
+      width: 767px;
+    }
+    @media (max-width: 767px) {
+      width: 390px;
+    }
+  `,
+  textline: styled.p`
+    font-size: ${theme.fontSize.xxs};
+  `,
+};
+
+export default Styled;

--- a/components/common/Footer/Footer.tsx
+++ b/components/common/Footer/Footer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Styled from './Footer.styled';
+
+const Footer: React.FC = () => {
+  return (
+    <Styled.footer>
+      <Styled.paragraph>
+        <Styled.textline>(주) 그루터기</Styled.textline>
+        <Styled.textline>Copyright 2022. 그루터기. All rights reserved.</Styled.textline>
+        <Styled.textline>03674 서울특별시 서대문구 거북골로 34 (명지대학교)</Styled.textline>
+      </Styled.paragraph>
+    </Styled.footer>
+  );
+};
+
+export default Footer;

--- a/components/common/Footer/index.ts
+++ b/components/common/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -9,6 +9,7 @@ const color = {
   gray600: '#A7A7A7',
   gray700: '#979797',
   darkgray: '#4E4E4E',
+  deepdarkgray: '#3C424B',
   white: '#FFFFFF',
   black: '#000000',
   kakao: '#FEE500',


### PR DESCRIPTION
## 개요
공통적으로 사용되는 Footer컴포넌트를 만들었습니다.

Example: https://www.chromatic.com/component?appId=624819a68844fb003a06cdbc&csfId=components-footer&buildNumber=52&k=628f5492d6334e004a1c774c-1200-interactive-true&h=6&b=-1

## 작업내용
![image](https://user-images.githubusercontent.com/48820696/170467770-fe5125cb-77bf-4680-9a8b-df643aef8e0c.png)

## 주의사항
- content의 너비에 맞춰 헤더의 글씨 시작점도 이와 동일하게 설정하였습니다.
- 너비를 100vw, postion을 absolute로 설정하였습니다.
