### PR TITLE
Cache가 존재할 때 빌드되지 않는 오류 해결

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -37,10 +37,11 @@ jobs:
         id: next-js-cache
         with:
           path: |
+            ~/.npm
             ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Next-js-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Next-js-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            ${{ runner.os }}-Node-v${{ matrix.node-version }}-Next-js-
+            ${{ runner.os }}-Node-v${{ matrix.node-version }}-Next-js-${{ hashFiles('**/yarn.lock') }}-
 
       - name: Install dependencies
         if: |
@@ -48,8 +49,6 @@ jobs:
         run: yarn install
 
       - name: Build
-        if: |
-          steps.next-js-cache.outputs.cache-hit != 'true'
         run: yarn build
         env:
           SERVER_URL: ${{ secrets.SERVER_URL }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --no-lint",
     "start": "next start",
     "lint": "eslint --cache \"**/*.{js,ts,jsx,tsx}\"",
     "format": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md,yml,html}\"",


### PR DESCRIPTION
## 개요
코드 변경사항이 있음에도 불구하고 빌드를 실행하지 않는 오류 해결

❕기존 `yarn build` 시간 `42s` -> `15s`로 단축

## 작업내용
- Cache가 존재할 때 빌드되지 않게 하는 설정 제거
- `next build`에 no-lint 옵션 추가
- Cache 대상에 `~./npm` 추가

## 주의사항
속도가 다시 살짝 느려졌습니다.
