### PR TITLE
Call scroll api based on data.pageCount

### DIFF
--- a/components/search/SearchList/SearchList.tsx
+++ b/components/search/SearchList/SearchList.tsx
@@ -15,9 +15,9 @@ const SearchList = () => {
     ['posts', searchState],
     async ({ pageParam = 1 }) => (await post.search({ searchState, pageParam })).data,
     {
-      getNextPageParam: (lastPage, pages) => {
-        if (pages.length < 1) return pages.length + 1;
-        else return undefined;
+      getNextPageParam: (lastPage, allPages) => {
+        if (lastPage === undefined) return undefined;
+        else return allPages.length < lastPage?.data?.pageCount && allPages.length + 1;
       },
     },
   );

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -5,7 +5,7 @@ interface ResponseData {
   headers?: AxiosResponseHeaders;
   status: number;
   message?: string;
-  data?: JSON;
+  data?: any;
 }
 
 export const GAxios = axios.create({


### PR DESCRIPTION
## 개요
샘플 데이터가 쌓여서, 전체 페이지 수를 받아 api를 호출하도록 변경.

## 작업내용
```
{
  posts: [
    {
      postId: number;
      title: string;
      content: string;
      imageUrl: string;
      hashtags: string[];
    },
  ];
  pageCount: number;
};
```
pageCount를 사용해 다음 페이지 호출함.

## 주의사항
interface ResponseData {
  headers?: AxiosResponseHeaders;
  status: number;
  message?: string;
  data?: any;
}
data: any 인 Promise<ResponseData>를 리턴함.